### PR TITLE
Zero values should be replaced in the template

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,8 @@ var pope = function (string, data, options) {
   while (result = regex.exec(string)){
     var item = result[1].trim()
     if(item) {
-      var value = prop(data, item) || null
-      if (value) {
+      var value = prop(data, item)
+      if (value !== undefined && value !== null) {
         formattedString = formattedString.replace(result[0], value)
       } else if (options.throwOnUndefined) {
         const error = new Error('Missing value for ' + result[0])

--- a/test/pope.spec.js
+++ b/test/pope.spec.js
@@ -98,4 +98,10 @@ describe('pope', function   () {
   it('work fine with nested values', function () {
     expect(pope("Hello {{ user.username }}", { user: { username: 'virk' } })).to.equal('Hello virk')
   })
+
+  it('should replace a value whose value is zero', function () {
+    const template = pope("Zero value {{index}}", {index: 0})
+    expect(template).to.equal('Zero value 0')
+  })
+
 })


### PR DESCRIPTION
When there is a key with a value of zero, it doesn't get the zero back in the replaced string, it just puts an empty string.

I added a test to contemplate this case and a possible work around.
I think the if that causes the problem is trying to save the case of having a null or undefined value, and then puts an empty string in that case. But the condition is also swallowing the case of having a zero value, which is contemplated in the the else clause.

I hope this is a useful bugfix for the package :)